### PR TITLE
Tableau Hyper API Connection No Longer Replace Hyper File in Dir

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,8 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/.idea/ETL-excel-to-hyper-tableau.iml
+++ b/.idea/ETL-excel-to-hyper-tableau.iml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="PYTHON_MODULE" version="4">
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/.idea/inspectionProfiles/profiles_settings.xml
+++ b/.idea/inspectionProfiles/profiles_settings.xml
@@ -1,0 +1,6 @@
+<component name="InspectionProjectProfileManager">
+  <settings>
+    <option name="USE_PROJECT_PROFILE" value="false" />
+    <version value="1.0" />
+  </settings>
+</component>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectRootManager" version="2" project-jdk-name="Python 3.11 (ExcelToTableau)" project-jdk-type="Python SDK" />
+</project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/ETL-excel-to-hyper-tableau.iml" filepath="$PROJECT_DIR$/.idea/ETL-excel-to-hyper-tableau.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/fsheet.py
+++ b/fsheet.py
@@ -1,4 +1,4 @@
-from typing import List, Any
+from typing import Any
 
 import pandas as pd
 import os

--- a/query_iterator.py
+++ b/query_iterator.py
@@ -1,10 +1,8 @@
 import itertools
 import os
 from collections import namedtuple
-
 import pandas as pd
 from query_bundle import QueryBundle
-from typing import Union
 import sqlite3
 from tableauhyperapi import HyperProcess, Telemetry, Connection, CreateMode, NOT_NULLABLE, NULLABLE, \
     SqlType, TableDefinition, Inserter, escape_name, escape_string_literal, HyperException, TableName
@@ -155,7 +153,7 @@ class QueryIterator:
         for query_bundle in self.query_bundles:
             export_file_name = query_bundle.export_file_name
             hyper_table_name = f"{query_bundle.export_file_name}.hyper"
-            with Connection(hyper.endpoint, hyper_table_name, CreateMode.CREATE_AND_REPLACE) as connection:
+            with Connection(hyper.endpoint, hyper_table_name, CreateMode.CREATE) as connection:
                 for query in query_bundle.queries:
                     query_name = query.query_name
                     print(f"Starting hyper conversion of table {query_name}")

--- a/run_main.py
+++ b/run_main.py
@@ -1,25 +1,9 @@
-
 import os
 from query_bundle import QueryBundle
 from query_iterator import QueryIterator
-from query import Query
-
-# TO DO: Make index = 1 cause concatenation by rows instead of columns. Will have to use a specific row to pivot the data on,
-# or is there a parameter to use?
 
 # Manually enter queries here, future development can allow for user console input
 def create_query_bundles():
-
-    # Checks that all export file names among QueryBundle objects are unique
-    # Query sheets should be formatted as "sheet_name.sheet"
-    def unique_bundle_names(query_bundles: list[QueryBundle]):
-        bundle_names = []
-        for query_bundle in query_bundles:
-            for processed_name in bundle_names:
-                if query_bundle.export_file_name == processed_name:
-                    raise Exception(f"Export file name {processed_name} is not unique. All export file names must be unique.")
-
-    # Format: query_names, queries, matches, sheets, axis
     # Ex: age_per_year = QueryBundle(
     #         export_file_name="two_queries_test",
     #         _query_names=["all_age", "all_activity"],
@@ -33,7 +17,8 @@ def create_query_bundles():
     retirement_summary = QueryBundle(
         export_file_name="retirement_summary",
         _query_names=["retirement_summary"],
-        _query_strings=["SELECT COUNT([Status ID]) as num_retirements, ROUND(AVG(Age), 2) as avg_age FROM DEL.sheet WHERE [Status Id] = 'RT'"],
+        _query_strings=[
+            "SELECT COUNT([Status ID]) as num_retirements, ROUND(AVG(Age), 2) as avg_age FROM DEL.sheet WHERE [Status Id] = 'RT'"],
         matches=range(2015, 2022),
         sheets=['DEL'],
         combine_columns=[True]
@@ -44,7 +29,6 @@ def create_query_bundles():
     for value in local_values.values():
         if isinstance(value, QueryBundle):
             query_bundles.append(value)
-    unique_bundle_names(query_bundles)
     return query_bundles
 
 


### PR DESCRIPTION
tableauhyperapi.Connection constructor in query_iterator.py now will throw an error if an export .hyper file name already exists in the directory. Prevents user from accidentally exporting two QueryBundle objects to the same export fie and replacing needed data. Redundant code in the run_main example file was removed.

Unused packages and imports also removed from files, unrelated to above change.